### PR TITLE
Fix RuggedPOD API installation

### DIFF
--- a/modules/ruggedpod/initialize/scripts/00-keepalive.sh
+++ b/modules/ruggedpod/initialize/scripts/00-keepalive.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+log_alive() {
+    while true ; do
+        sleep 120
+        echo "[$(date "+%Y-%m-%d %H:%M:%S")] RuggedPOD image provisioning is still in progress..."
+    done
+}
+
+log_alive &

--- a/modules/ruggedpod/provision/scripts/30-ruggedpod-api.sh
+++ b/modules/ruggedpod/provision/scripts/30-ruggedpod-api.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-set -x
+set -eux
 
-pip install git+https://github.com/RuggedPOD/ruggedpod-api.git &
-
-pid=$!
-
-while true ; do
-    ps -o pid= -p $pid
-    if [ $? -ne 0 ] ; then
-        echo "RuggedPOD API installation is done"
-        exit 0
-    fi
-    sleep 60
-    echo "Waiting for RuggedPOD API installation to complete..."
-done
+pip install git+https://github.com/RuggedPOD/ruggedpod-api.git


### PR DESCRIPTION
Running a background command in the chroot context
fails with the current setup. It was actually not
necessary. This was only to be sure to write
periodically in the log file to avoid travis think
the build is stuck.

Replacing it by a dummy script that writes in the
log in a loop makes the trick even if it's pretty
dirty.
