### PR TITLE
Remove the serial port redirection to the console

### DIFF
--- a/modules/ruggedpod/finish/files/boot/cmdline.txt
+++ b/modules/ruggedpod/finish/files/boot/cmdline.txt
@@ -1,0 +1,1 @@
+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait bcm2708.vc_i2c_override=1


### PR DESCRIPTION
This default behaviour configured in the basic module restricts the serial port usage. Removing this config allows to use the serial port to communicate with external devices.
