### PR TITLE
[WIP] [UNTESTED] Expand root filesystem at first boot

### DIFF
--- a/modules/ruggedpod/finish/files/etc/rc5.d/S00ExpandFilesystem
+++ b/modules/ruggedpod/finish/files/etc/rc5.d/S00ExpandFilesystem
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eux
+
+raspi-config --expand-rootfs
+
+rm -f /etc/rc5.d/S00ExpandFilesystem
+reboot

--- a/modules/ruggedpod/finish/scripts/10-make-script-executatble.sh
+++ b/modules/ruggedpod/finish/scripts/10-make-script-executatble.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ex
+
+chmod +x /etc/rc5.d/S00ExpandFilesystem

--- a/modules/ruggedpod/provision/files/etc/apt/sources.list
+++ b/modules/ruggedpod/provision/files/etc/apt/sources.list
@@ -1,0 +1,2 @@
+deb http://archive.raspbian.org/raspbian jessie main contrib non-free
+deb http://archive.raspberrypi.org/debian jessie main

--- a/modules/ruggedpod/provision/scripts/00-update-apt.sh
+++ b/modules/ruggedpod/provision/scripts/00-update-apt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux
+
+apt-get update

--- a/modules/ruggedpod/provision/scripts/05-install-raspi-config.sh
+++ b/modules/ruggedpod/provision/scripts/05-install-raspi-config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux
+
+apt-get install -y --force-yes raspi-config

--- a/modules/ruggedpod/provision/scripts/10-system-dependencies.sh
+++ b/modules/ruggedpod/provision/scripts/10-system-dependencies.sh
@@ -2,5 +2,6 @@
 
 set -eux
 
-apt-get install -y git apache2 apache2-dev python-dev python-pip libxml2-dev \
-                   libxslt1-dev zlib1g-dev libffi-dev libssl-dev python-smbus
+apt-get install -y --force-yes \
+             git apache2 apache2-dev python-dev python-pip libxml2-dev \
+             libxslt1-dev zlib1g-dev libffi-dev libssl-dev python-smbus


### PR DESCRIPTION
Fix #26

It involves a double boot because a reboot is needed
to refresh the partition table.
